### PR TITLE
chore: add Go-specific .gitignore and remove README header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Created by https://www.toptal.com/developers/gitignore/api/go
+# Edit at https://www.toptal.com/developers/gitignore?templates=go
+
+### Go ###
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+# Mac OS X files
+.DS_Store
+
+# End of https://www.toptal.com/developers/gitignore/api/go

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# backend


### PR DESCRIPTION
- Added a comprehensive .gitignore file tailored for Go projects to exclude common build artifacts, test binaries, coverage files, and OS-specific files  
- Removed the redundant README header to clean up the project root